### PR TITLE
Fix audio download settings and improve mobile UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -660,7 +660,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     offlinePlayer.connect(offlineDryGain);
                     offlinePlayer.connect(offlineWetGain);
                     offlinePlayer.start(0);
-                }, player.buffer.duration);
+                }, player.buffer.duration / playbackRate);
 
                 // Use MP3 encoding for better quality and smaller file size
                 const ch0 = buffer.getChannelData(0);

--- a/style.css
+++ b/style.css
@@ -206,7 +206,7 @@ body {
 }
 
 .toolbar-btn i {
-    font-size: 20px;
+    font-size: 18px;
     transition: transform 0.3s ease;
 }
 
@@ -238,17 +238,18 @@ body {
 
 @media (max-width: 768px) {
     .player-toolbar {
-        gap: 8px;
-        padding: 12px;
+        gap: 6px;
+        padding: 10px;
+        flex-wrap: nowrap;
     }
     
     .toolbar-btn {
-        min-width: 70px;
-        padding: 12px 16px;
+        min-width: 65px;
+        padding: 10px 12px;
     }
     
     .toolbar-btn i {
-        font-size: 18px;
+        font-size: 16px;
     }
     
     .toolbar-btn span {
@@ -257,14 +258,20 @@ body {
 }
 
 @media (max-width: 480px) {
-    .toolbar-btn {
-        min-width: 60px;
-        padding: 10px 12px;
+    .player-toolbar {
         gap: 4px;
+        padding: 8px;
+        flex-wrap: nowrap;
+    }
+    
+    .toolbar-btn {
+        min-width: 55px;
+        padding: 8px 10px;
+        gap: 3px;
     }
     
     .toolbar-btn i {
-        font-size: 16px;
+        font-size: 14px;
     }
     
     .toolbar-btn span {
@@ -814,8 +821,8 @@ body {
     }
 
     .knob-container {
-        width: 180px;
-        height: 180px;
+        width: 144px;
+        height: 144px;
     }
 
     .knob-wrapper {
@@ -860,8 +867,8 @@ body {
     }
 
     .knob-container {
-        width: 160px;
-        height: 160px;
+        width: 128px;
+        height: 128px;
     }
 
     .knob-wrapper {


### PR DESCRIPTION
## Summary
This PR addresses Issue #25 by fixing the critical audio download bug and improving mobile user experience.

## 🎵 Audio Download Fix
**Problem**: Downloaded audio files didn't reflect the applied speed settings - files played at original speed regardless of the speed knob setting.

**Root Cause**: The offline rendering duration was incorrectly set to `player.buffer.duration` instead of accounting for the playback rate change.

**Solution**: Fixed the duration calculation to `player.buffer.duration / playbackRate`
- ✅ 50% speed now produces 2x longer audio files
- ✅ 200% speed now produces 0.5x shorter audio files  
- ✅ Downloaded audio now ALWAYS reflects applied settings

## 📱 Mobile UI Improvements
**Toolbar Icon Optimization**: Reduced icon sizes by 10% across all breakpoints
- Desktop: 20px → 18px
- Mobile (768px): 18px → 16px
- Mobile (480px): 16px → 14px

**Mobile Responsiveness Enhancements**:
- ✅ All 6 toolbar buttons now stay in one row on mobile devices
- ✅ Knob containers reduced by 20% on mobile (180px → 144px, 160px → 128px)
- ✅ Optimized spacing and padding for compact mobile layout
- ✅ Download button no longer excluded from toolbar row

## 🧪 Testing
- [x] Verified audio download reflects speed settings correctly
- [x] Tested toolbar responsiveness on mobile breakpoints
- [x] Confirmed all buttons remain accessible in single row
- [x] Validated knob container sizing improvements
- [x] Tested both light and dark themes

## 📋 Files Changed
- `script.js`: Fixed offline rendering duration calculation
- `style.css`: Updated icon sizes and mobile responsive styles

## 🔗 Closes
Fixes #25

---
**Impact**: This fix ensures the download feature works as expected and provides a better mobile experience with more compact, accessible controls.

@myaiplug can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5515b1abc6a74a27bdf9969bd5122199)